### PR TITLE
Send Slack messages async with retries using Celery

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ It supports variable frequency and length for rounds of matching, multiple match
 
 ## Tech stack
 
-- Django running on Python 3.7+
+- [Django](https://www.djangoproject.com/) running on Python 3.7+
 - SQLite 3 (you can change databases if you need something more robust, but it's not a particularly database-intensive application)
-- Slack Python SDK
+- [Celery](http://www.celeryproject.org/) running on [RabbitMQ](https://www.rabbitmq.com/) as an async task queue for sending messages
 
 **Need to use the Slack [Real-Time Messaging (RTM) API](https://api.slack.com/rtm) instead of the [Events API](https://api.slack.com/events-api)?** Check out the `rtm` branch. You will need to use the RTM API if you're inside a corporate intranet or firewall that won't allow you to receive events from Slack on a publicly accessible URL. The `rtm` branch has a Node.js proxy server under `rtmProxy/` that connects to the socket-based RTM API and forwards events to the Django server. 
 
@@ -120,6 +120,7 @@ From the admin interface, under "Matcher" you can click "Matches" to see a full 
 
 - Python 3.7+ (the code uses F-strings which aren't available in earlier versions of Python 3)
 - Pip 3
+- [RabbitMQ](https://www.rabbitmq.com/download.html)
 
 ### Installation
 
@@ -130,7 +131,7 @@ From the admin interface, under "Matcher" you can click "Matches" to see a full 
 5. `cd [repo]`
 6. `pip3 install -r requirements.txt`
 
-### Configuring the server
+### Configuring the web server
 
 1. Create and set required environment variables in your environment: `SECRET_KEY` (required; a long random string for Django's cryptography), `SLACK_API_TOKEN` (required; a bot token to connect to Slack, usually starts with "xoxb-"), `SLACK_SIGNING_SECRET` (required; used to verify that requests are from Slack), `ADMIN_SLACK_USER_ID` (optional; Slack user ID for the admin who people should contact if they have questions)
 2. `python manage.py collectstatic` to move static files for serving
@@ -139,6 +140,16 @@ From the admin interface, under "Matcher" you can click "Matches" to see a full 
 5. `python manage.py createsuperuser` to create your user to log in to the admin
 6. Start the server! In development this will be `python3 manage.py runserver`. In production this might be `gunicorn meetups.wsgi`.
 7. Log in to the admin and follow the steps above to set up a matching pool. The admin URL is `<your base url>:<port number>/admin/`.
+
+### Configuring the Celery task queue
+
+In order to send Slack messages from the bot, you also need to run a Celery task queue. This queue allows the bot to send messages asyncronously and retry if sending fails, which can happen if there are network issues or the bot gets rate-limited by the Slack API.
+
+After installing RabbitMQ (see Prerequisites above), do the following:
+
+1. Start the RabbitMQ broker by running `rabbitmq-server`
+2. In a separate terminal window, source the virtualenv with the command `source bin/activate` (or whatever the path to the `activate` script is)
+3. Start the Celery task queue: `celery -A matcher.slack worker --loglevel=info`
 
 ## TODO
 
@@ -150,7 +161,7 @@ MVP requirements done!
 
 - automatic reporting of stats
 - analytics graphs
-- can we determine when a person joined Slack and use that info somehow?
 - unit tests? maybe? 🙃
+- notify the admin when the bot receives a query it doesn't know how to handle and allow the admin to respond from the bot
 
 _This Slack bot is in no way endorsed by or affiliated with Slack Technologies or their product, Slack._

--- a/matcher/slack.py
+++ b/matcher/slack.py
@@ -1,20 +1,113 @@
+import os
 import logging
+from random import random
 
 import slack
+from celery import Celery
 
 from meetups import settings
- # importing in this format to avoid circular ImportError
-import matcher.models as models
+import matcher.messages as messages
 
+# Note: The Celery worker requires this environment variable to be set in this
+# file for the `open_match_dm` task to work, or it will raise exception:
+# "django.core.exceptions.ImproperlyConfigured: Requested setting
+# INSTALLED_APPS, but settings are not configured. You must either define the
+# environment variable DJANGO_SETTINGS_MODULE or call settings.configure()
+# before accessing settings."
+# I am not 100% sure why, but I suspect it is because of the dynamic import in
+# that task.
+os.environ["DJANGO_SETTINGS_MODULE"] = "meetups.settings"
+
+# Celery setup
+app = Celery("tasks", broker=settings.CELERY_BROKER_URL)
+# how many times to retry a request
+# https://github.com/celery/celery/issues/976#issuecomment-233663171
+app.Task.max_retries = 5
+# maximum time to wait before retrying a request in seconds
+MAX_WAIT_TIME = 60 * 2
 
 logger = logging.getLogger(__name__)
 client = slack.WebClient(token=settings.SLACK_API_TOKEN)
 
-# send a direct message to a user as the bot
-def send_dm(user_id, *args, **kwargs):
+
+def get_wait_time(exception, request):
+    """get how long a request should wait before retrying, from the Slack API
+    response's Retry-After header, if available, or using an exponential
+    backoff based on the current retry number
+    """
     try:
-        client.chat_postMessage(channel=user_id, as_user=True, *args, **kwargs)
-    except slack.errors.SlackApiError as error:
-        message_text = kwargs.get("text")
-        logger.error(f"Failed to send Slack message \"{message_text}\" to "
-            f"user {user_id}. Error: {error}")
+        return exception.response["headers"]["Retry-After"]
+    except (KeyError, AttributeError):
+        # wait exponentially longer before reattempting the request with
+        # random jitter. adapted from:
+        # https://github.com/slackapi/python-slackclient/blob/647f7ab4182ae6055dee80d6c4e062f30fa45078/slack/rtm/client.py#L510
+        return min((2 ** request.retries) + random(), MAX_WAIT_TIME)
+
+
+def get_retries_remaining(self):
+    """get the number of retries remaining before the task will fail
+    """
+    return self.max_retries - self.request.retries
+
+
+@app.task(bind=True)
+def send_dm(self, user_id, **kwargs):
+    """send a direct message to a user as the bot
+    """
+    message_text = kwargs.get("text", kwargs.get("blocks"))
+    try:
+        client.chat_postMessage(channel=user_id, as_user=True, **kwargs)
+    except Exception as exception: # see [1] (bottom of file)
+        wait_time = get_wait_time(exception, self.request)
+        logger.warning(f"Failed to send message \"{message_text}\" to user "
+            f"{user_id}. Retrying in {wait_time} seconds. Error: "
+            f"{exception}. {get_retries_remaining(self)} retries remaining.")
+        raise self.retry(exc=exception, countdown=wait_time)
+    return f"{user_id}: \"{message_text}\"" # logged to Celery worker
+
+
+@app.task(bind=True)
+def open_match_dm(self, match_id):
+    """create a group direct message between the two people in a match and
+    introduce them to each other
+    """
+     # import within the function to avoid a circular ImportError
+    import matcher.models as models
+    match = models.Match.objects.get(pk=match_id)
+    user_ids = ",".join([match.person_1.user_id, match.person_2.user_id])
+    # https://api.slack.com/methods/conversations.open
+    try:
+        response = client.conversations_open(users=user_ids)
+        match.conversation_id = response["channel"]["id"]
+    except Exception as exception: # see [1] (bottom of file)
+        wait_time = get_wait_time(exception, self.request)
+        logger.warning(f"Failed to open conversation for match: {match}. "
+            f"Retrying in {wait_time} seconds. Error: {exception}. "
+            f"{get_retries_remaining(self)} retries remaining.")
+        raise self.retry(exc=exception, countdown=wait_time)
+    match.save()
+    # send people's introductions to each other in the channel
+    # `unfurl_links=False` prevents link previews from appearing if someone
+    # included a link in their intro
+    try:
+        client.chat_postMessage(channel=match.conversation_id, as_user=True,
+            text=messages.MATCH_INTRO.format(person_1=match.person_1,
+            person_2=match.person_2, pool=match.round.pool),
+            unfurl_links=False)
+    except Exception as exception: # see [1] (bottom of file)
+        wait_time = get_wait_time(exception, self.request)
+        logger.warning(f"Failed to send message for match: {match}. "
+            f"Retrying in {wait_time} seconds. Error: {exception}. "
+            f"{get_retries_remaining(self)} retries remaining.")
+        raise self.retry(exc=exception, countdown=wait_time)
+    logger.info(f"Sent message for match: {match}.")
+    return match # logged to Celery worker
+
+
+# [1]: It's a bit of an antipattern to catch all exceptions in Python. The
+# reason we're doing it here is because there are simply too many HTTP-related
+# exceptions that can be raised from different modules that aren't direct
+# dependencies of this project. As such, we don't want to create a dependency
+# on an implementation detail of, for example, the HTTP client that the Slack
+# SDK uses by importing its error messages in this file, as this would go
+# against the principle of encapsulation.

--- a/matcher/views.py
+++ b/matcher/views.py
@@ -104,7 +104,7 @@ def update_intro(event):
         )
         logger.info(f"Received query from unregistered user {user_id}: "\
             f"\"{message_text}\".")
-        send_dm(user_id,
+        send_dm.delay(user_id,
             text=messages.UNREGISTERED_PERSON.format(channels=channels_list))
         return HttpResponse(204)
     # if this person has an intro already, we aren't expecting any further
@@ -116,7 +116,7 @@ def update_intro(event):
         else:
             contact_phrase = "."
         logger.info(f"Received unknown query from {person}: \"{message_text}\".")
-        send_dm(user_id, 
+        send_dm.delay(user_id,
             text=messages.UNKNOWN_QUERY.format(contact_phrase=contact_phrase))
     else:
         # onboard new Person
@@ -131,7 +131,7 @@ def update_intro(event):
         if ADMIN_SLACK_USER_ID:
             message += (" " + messages.INTRO_RECEIVED_QUESTIONS\
                 .format(ADMIN_SLACK_USER_ID=ADMIN_SLACK_USER_ID))
-        send_dm(user_id, text=message)
+        send_dm.delay(user_id, text=message)
     return HttpResponse(204)
 
 
@@ -170,7 +170,7 @@ def update_availability(payload, action, pool_id):
     else:
         message = messages.UPDATED_UNAVAILABLE
     logger.info(f"Set the availability of {person} in {pool} to {available}.")
-    send_dm(user_id, text=message)
+    send_dm.delay(user_id, text=message)
     ask_if_met(user_id, pool)
     return HttpResponse(204)
 
@@ -197,7 +197,7 @@ def ask_if_met(user_id, pool):
             latest_match.id,
             {"pool": pool, "other_person": other_person}
         )
-        send_dm(user_id, blocks=blocks)
+        send_dm.delay(user_id, blocks=blocks)
     return HttpResponse(204)
 
 
@@ -241,5 +241,5 @@ def update_met(payload, action, block_id):
         message = messages.MET.format(other_person=other_person)
     else:
         message = messages.DID_NOT_MEET
-    send_dm(user_id, text=message)
+    send_dm.delay(user_id, text=message)
     return HttpResponse(204)

--- a/meetups/settings.py
+++ b/meetups/settings.py
@@ -33,7 +33,7 @@ else:
 ALLOWED_HOSTS = [
     "localhost",
     "127.0.0.1",
-    "1f8eb9f7.ngrok.io",
+    "08db7184.ngrok.io",
     "slack-meetups.appspot.com"
 ]
 
@@ -152,6 +152,9 @@ LOGGING = {
         },
     },
 }
+
+# Celery config
+CELERY_BROKER_URL = "pyamqp://guest@localhost//"
 
 
 # token comes from this page: https://api.slack.com/apps/AH99D6ZLH/install-on-team

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==2.2.10
 slackclient==2.1.0
+celery==4.4.2


### PR DESCRIPTION
This is a necessary step to scale the bot to dealing with matching in larger pools. Right now, the bot sends messages completely synchronously, which can cause it to time out on pools of ~50+ people. In some cases with even more people, the bot will get ratelimited and there's no mechanism in place to retry the request later. 

This PR adds support for that with the Python task queue [Celery](http://www.celeryproject.org/). Yes, it's one more dependency and thing to run, but it should make the bot significantly more robust in dealing with API issues and allow it to scale to much larger pools.